### PR TITLE
Add user grant count limits for access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A decentralized system for protecting sensitive data on the Stacks blockchain. D
 - Track access history
 - Data owner controls
 - Permission management system
+- Grant count limits per user (NEW)
 
 ## Getting Started
 
@@ -22,7 +23,7 @@ A decentralized system for protecting sensitive data on the Stacks blockchain. D
 
 ## Time-Limited Access Control
 
-The new time-limited access control feature allows data owners to grant temporary access to their data. When granting access, owners can specify an expiry block height after which the access will automatically expire.
+The time-limited access control feature allows data owners to grant temporary access to their data. When granting access, owners can specify an expiry block height after which the access will automatically expire.
 
 Example usage:
 ```clarity
@@ -31,3 +32,18 @@ Example usage:
 ```
 
 Use `check-access` to verify if access is still valid - it will return false if the permission has expired.
+
+## Grant Count Limits
+
+To prevent potential abuse and ensure responsible access management, each user is now limited to granting access to a maximum of 10 other users at any time. This limit applies to both permanent and time-limited access grants.
+
+The system automatically:
+- Tracks the number of active grants per user
+- Increments the count when granting access
+- Decrements the count when revoking access
+- Prevents new grants if the limit is reached
+
+You can check a user's current grant count using:
+```clarity
+(get-grant-count <user-principal>)
+```


### PR DESCRIPTION
This PR introduces a new security feature that limits the number of active access grants a user can have at any time. The enhancement helps prevent potential abuse while maintaining the system's core functionality.

Key Changes:
- Added maximum limit of 10 active grants per user
- Implemented grant counting system with automatic tracking
- Added new error constant for max grants reached (err u105)
- Created new read-only function to check current grant count
- Updated grant and revoke functions to maintain count accuracy
- Added comprehensive tests for the new functionality
- Updated documentation to reflect the new feature

The changes are fully backward compatible and introduce no breaking changes to existing functionality. The grant count limit adds an important security boundary while maintaining flexibility for legitimate use cases.

Testing:
- Added new test suite specifically for grant count limits
- Updated existing tests to verify count tracking
- Verified all existing functionality continues to work as expected